### PR TITLE
addressing deprecated json_normalize

### DIFF
--- a/02_deploy_and_monitor/deploy_and_monitor.ipynb
+++ b/02_deploy_and_monitor/deploy_and_monitor.ipynb
@@ -386,7 +386,7 @@
     "import pandas as pd\n",
     "\n",
     "baseline_job = my_default_monitor.latest_baselining_job\n",
-    "schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
+    "schema_df = pd.json_normalize(baseline_job.baseline_statistics().body_dict[\"features\"])\n",
     "schema_df.head(10)"
    ]
   },
@@ -403,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "constraints_df = pd.io.json.json_normalize(baseline_job.suggested_constraints().body_dict[\"features\"])\n",
+    "constraints_df = pd.json_normalize(baseline_job.suggested_constraints().body_dict[\"features\"])\n",
     "constraints_df.head(10)"
    ]
   },
@@ -704,7 +704,7 @@
     "file = open('monitoring/constraint_violations.json', 'r')\n",
     "data = file.read()\n",
     "\n",
-    "violations_df = pd.io.json.json_normalize(json.loads(data)['violations'])\n",
+    "violations_df = pd.json_normalize(json.loads(data)['violations'])\n",
     "violations_df.head(10)"
    ]
   },


### PR DESCRIPTION
/tmp/ipykernel_32372/765576352.py:4: FutureWarning: pandas.io.json.json_normalize is deprecated, use pandas.json_normalize instead
  schema_df = pd.io.json.json_normalize(baseline_job.baseline_statistics().body_dict["features"])

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
