### PR TITLE
Endpoint Argument Name change

### DIFF
--- a/02_deploy_and_monitor/deploy_and_monitor.ipynb
+++ b/02_deploy_and_monitor/deploy_and_monitor.ipynb
@@ -656,7 +656,7 @@
    "outputs": [],
    "source": [
     "s3_client = boto3.Session().client('s3')\n",
-    "monitoring_reports_prefix = '{}/monitoring/reports/{}'.format(prefix, pred.endpoint)\n",
+    "monitoring_reports_prefix = '{}/monitoring/reports/{}'.format(prefix, pred.endpoint_name)\n",
     "\n",
     "result = s3_client.list_objects(Bucket=bucket_name, Prefix=monitoring_reports_prefix)\n",
     "try:\n",

--- a/02_deploy_and_monitor/deploy_and_monitor.ipynb
+++ b/02_deploy_and_monitor/deploy_and_monitor.ipynb
@@ -538,7 +538,7 @@
     "from sagemaker.model_monitor import CronExpressionGenerator\n",
     "from time import gmtime, strftime\n",
     "\n",
-    "endpoint_name = pred.endpoint\n",
+    "endpoint_name = pred.endpoint_name\n",
     "\n",
     "mon_schedule_name = 'nw-traffic-classification-xgb-mon-sch-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
     "my_default_monitor.create_monitoring_schedule(\n",


### PR DESCRIPTION
Endpoint Argument Name
For sagemaker.predictor.Predictor, sagemaker.sparkml.model.SparkMLPredictor, and predictors for Amazon algorithm (e.g. Factorization Machines, Linear Learner, etc.), the endpoint attribute has been renamed to endpoint_name.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
